### PR TITLE
Use lower case repo path for logrus import

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The hook must be configured with:
 ```go
 import (
     "log/syslog"
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "gopkg.in/gemnasium/logrus-airbrake-hook.v2" // the package is named "aibrake"
     )
 
@@ -36,7 +36,7 @@ Note that if environment == "development", the hook will not send anything to ai
 ```go
 import (
     "log/syslog"
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "gopkg.in/gemnasium/logrus-airbrake-hook.v2" // the package is named "aibrake"
     )
 

--- a/airbrake.go
+++ b/airbrake.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/airbrake/gobrake.v2"
 )
 

--- a/airbrake_test.go
+++ b/airbrake_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"gopkg.in/airbrake/gobrake.v2"
 )
 


### PR DESCRIPTION
Logrus repo path changed, the username part is now lower case.
See https://github.com/sirupsen/logrus/issues/451#issuecomment-264332021